### PR TITLE
Drop empty GH action on issue comments

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,9 +6,6 @@ permissions:
   actions: read
 
 on:
-  issue_comment:
-    types:
-      - created
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths-ignore:


### PR DESCRIPTION
previously each comment triggered a GH action, which then had no jobs defined to do; this PR drops this empty action